### PR TITLE
canvas responsive when resizing

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -62,3 +62,10 @@ document.addEventListener("DOMContentLoaded", function () {
     mouse.y = event.y;
   });
 });
+
+window.addEventListener("resize", () => {
+  var canvas = document.getElementById("preloaderCanvas");
+
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+});


### PR DESCRIPTION
This pull request includes a small change to the `assets/js/custom.js` file. The change adds an event listener to handle window resize events and adjust the dimensions of the `preloaderCanvas` element accordingly.

* [`assets/js/custom.js`](diffhunk://#diff-af1b0d0d7c968935aa63bba9e56562139791c575b78fb492a791b047325ff360R65-R71): Added a `resize` event listener to update the `preloaderCanvas` dimensions based on the window size.